### PR TITLE
Add save/load functionality to prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,7 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# Python
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# rogue-manager
+# Rogue Manager
+
+Simple prototype demonstrating a save feature for game state.
+
+## Usage
+
+```python
+from rogue_manager.game import Game
+
+game = Game("Hero")
+# modify game state
+loaded_game = Game.load()  # loads from savegame.json if it exists
+```

--- a/rogue_manager/__init__.py
+++ b/rogue_manager/__init__.py
@@ -1,0 +1,1 @@
+"""Rogue Manager game prototype package."""

--- a/rogue_manager/game.py
+++ b/rogue_manager/game.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class Game:
+    """Simple game state container with save and load support."""
+
+    player_name: str
+    level: int = 1
+    inventory: List[str] = field(default_factory=list)
+
+    def save(self, path: str = "savegame.json") -> None:
+        """Save the current game state to *path* as JSON."""
+        data = {
+            "player_name": self.player_name,
+            "level": self.level,
+            "inventory": self.inventory,
+        }
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+
+    @classmethod
+    def load(cls, path: str = "savegame.json") -> Game:
+        """Load game state from *path* and return a :class:`Game` instance."""
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        return cls(**data)
+
+
+if __name__ == "__main__":
+    game = Game(player_name="Hero")
+    game.inventory.append("rusty sword")
+    game.save()
+    print("Game saved to savegame.json")

--- a/tests/test_save.py
+++ b/tests/test_save.py
@@ -1,0 +1,18 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from rogue_manager.game import Game
+
+
+def test_save_and_load(tmp_path):
+    save_path = tmp_path / "test_save.json"
+    game = Game("Hero", level=3, inventory=["sword", "potion"])
+    game.save(save_path)
+    assert save_path.exists()
+
+    loaded_game = Game.load(save_path)
+    assert loaded_game.player_name == "Hero"
+    assert loaded_game.level == 3
+    assert loaded_game.inventory == ["sword", "potion"]


### PR DESCRIPTION
## Summary
- introduce Game class with JSON save and load methods
- add test ensuring saved state can be restored
- document usage and ignore Python cache files

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68974207c8e48320abf1f2974575a36e