### PR TITLE
chore: add app build CI and tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI / app build
+on:
+  pull_request:
+    branches: [ feature/prototype-v0, main ]
+  push:
+    branches: [ feature/prototype-v0 ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: app
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        cache: npm
+        cache-dependency-path: app/package-lock.json
+    - run: npm ci
+    - run: npm run build

--- a/app/index.html
+++ b/app/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Rogue Manager</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,0 +1,30 @@
+{
+  "name": "app",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "app",
+      "version": "0.0.0",
+      "dependencies": {
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "zustand": "^4.5.2",
+        "zod": "^3.23.8",
+        "dayjs": "^1.11.10"
+      },
+      "devDependencies": {
+        "vite": "^5.0.10",
+        "typescript": "^5.3.3",
+        "tailwindcss": "^4.0.0-alpha.23",
+        "@tailwindcss/postcss": "^4.0.0-alpha.23",
+        "postcss": "^8.4.32",
+        "autoprefixer": "^10.4.16",
+        "@vitejs/plugin-react": "^4.2.1",
+        "@types/react": "^18.2.45",
+        "@types/react-dom": "^18.2.17"
+      }
+    }
+  }
+}

--- a/app/package.json
+++ b/app/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "app",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "zustand": "^4.5.2",
+    "zod": "^3.23.8",
+    "dayjs": "^1.11.10"
+  },
+  "devDependencies": {
+    "vite": "^5.0.10",
+    "typescript": "^5.3.3",
+    "tailwindcss": "^4.0.0-alpha.23",
+    "@tailwindcss/postcss": "^4.0.0-alpha.23",
+    "postcss": "^8.4.32",
+    "autoprefixer": "^10.4.16",
+    "@vitejs/plugin-react": "^4.2.1",
+    "@types/react": "^18.2.45",
+    "@types/react-dom": "^18.2.17"
+  }
+}

--- a/app/postcss.config.js
+++ b/app/postcss.config.js
@@ -1,0 +1,1 @@
+export default { plugins: { '@tailwindcss/postcss': {} } };

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import TopBar from './ui/TopBar';
+
+const App: React.FC = () => {
+  return (
+    <div className="min-h-screen bg-gray-100">
+      <TopBar />
+    </div>
+  );
+};
+
+export default App;

--- a/app/src/game/balance.ts
+++ b/app/src/game/balance.ts
@@ -1,0 +1,2 @@
+export const MAX_HP = 100;
+export const MAX_XP = 1000;

--- a/app/src/game/store.ts
+++ b/app/src/game/store.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+interface State {
+  hp: number;
+  setHp: (hp: number) => void;
+}
+
+export const useStore = create<State>((set) => ({
+  hp: 100,
+  setHp: (hp) => set({ hp })
+}));

--- a/app/src/game/time.ts
+++ b/app/src/game/time.ts
@@ -1,0 +1,3 @@
+import dayjs from 'dayjs';
+
+export const formatTime = (date: Date) => dayjs(date).format('HH:mm:ss');

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/app/src/ui/ProgressBar.tsx
+++ b/app/src/ui/ProgressBar.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+interface Props {
+  value: number;
+  max: number;
+}
+
+const ProgressBar: React.FC<Props> = ({ value, max }) => {
+  const width = Math.max(0, Math.min(100, (value / max) * 100));
+  return (
+    <div className="w-full bg-gray-200 h-4">
+      <div className="bg-blue-500 h-4" style={{ width: `${width}%` }} />
+    </div>
+  );
+};
+
+export default ProgressBar;

--- a/app/src/ui/TopBar.tsx
+++ b/app/src/ui/TopBar.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import ProgressBar from './ProgressBar';
+import { useStore } from '../game/store';
+import { MAX_HP } from '../game/balance';
+
+const TopBar: React.FC = () => {
+  const hp = useStore((s) => s.hp);
+  return (
+    <div className="p-2 bg-gray-800 text-white">
+      <ProgressBar value={hp} max={MAX_HP} />
+    </div>
+  );
+};
+
+export default TopBar;

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "react-jsx",
+    "allowJs": false,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "lib": ["ESNext", "DOM"],
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()]
+});


### PR DESCRIPTION
## Summary
- add CI workflow to build app with Node 20
- scaffold React + Vite app with Tailwind v4 and Zustand store
- configure PostCSS with @tailwindcss/postcss

## Testing
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/@tailwindcss%2fpostcss)
- `npm run build` (fails: vite: not found)

------
https://chatgpt.com/codex/tasks/task_e_68974bda4a048320853423d5bbf23fe2